### PR TITLE
fix desktop file persmission

### DIFF
--- a/bin/commands/install.dart
+++ b/bin/commands/install.dart
@@ -142,6 +142,10 @@ X-GDM-SessionRegisters=true
       'sudo',
       ['cp', desktopFilePath, '/usr/share/wayland-sessions/'],
     );
+    await runProcess(
+      'sudo',
+      ['chmod', 'a+r', '/usr/share/wayland-sessions/veshell.desktop'],
+    );
   }
 
   logger.success('\nSession installation completed\n');


### PR DESCRIPTION
After running `dart run veshell install -t release`, veshell does not appear in GDM list

Adding the read permissions to `/usr/share/wayland-sessions/veshell.desktop` fixes it
