### PR TITLE
update libgbm package name for fedora

### DIFF
--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -56,7 +56,7 @@
       <td>gbm</td>
       <td>libgbm</td>
       <td>libgm-devel</td>
-      <td>libgbm-dev or mesa-libgbm-devel</td>
+      <td>mesa-libgbm-devel</td>
     </tr>
     <tr>
       <td>openssl</td>


### PR DESCRIPTION
Added missing mesa- prefix for newer versions.

@PapyElGringo any suggestions on how to make the table look nicer? 